### PR TITLE
fix: parse url that start with git+https://

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+sudo: false
 language: node_js
 node_js:
-  - '0.11'
   - '0.10'
+  - '0.12'
+  - 1
+  - 2
+  - 3
+  - 4
 script: make test-coveralls

--- a/lib/giturl.js
+++ b/lib/giturl.js
@@ -30,9 +30,9 @@ exports.parse = function parse(sourceURL) {
 
   var url = sourceURL;
   if (url.indexOf('@') >= 0) {
-    url = url.replace(/^[^@]+@/, '');    // git@ || https://jpillora@ => ""
+    url = url.replace(/^[^@]+@/, '');    // `git@`` || `https://jpillora@` => ""
   }
-  url = url.replace(/^\w+:\/\//, '')    // git:// => ""
+  url = url.replace(/^[\w+]+:\/\//, '')    // `git://` || `git+https://` => ""
     .replace(/\.git$/, '');             // .git => ""
   var item = RE.exec(url);
   if (!item) {

--- a/test/giturl.test.js
+++ b/test/giturl.test.js
@@ -26,6 +26,7 @@ describe('giturl.test.js', function () {
       giturl.parse('https://github.com/banchee/tranquil.git').should.equal('https://github.com/banchee/tranquil');
       giturl.parse('https://github.com/banchee/tranquil').should.equal('https://github.com/banchee/tranquil');
       giturl.parse('http://github.com/banchee/tranquil.git').should.equal('https://github.com/banchee/tranquil');
+      giturl.parse('git+https://github.com/banchee/tranquil.git').should.equal('https://github.com/banchee/tranquil');
       giturl.parse('github.com/banchee/tranquil.git').should.equal('https://github.com/banchee/tranquil');
       giturl.parse('https://jpillora@github.com/banchee/tranquil.git').should.equal('https://github.com/banchee/tranquil');
       giturl.parse('git@github.com:cnpm/cnpm.git').should.equal('https://github.com/cnpm/cnpm');


### PR DESCRIPTION
This url is found  in npm registery, you can see the repo's url of koa by `npm info koa@latest`

```
repository: { type: 'git', url: 'git+https://github.com/koajs/koa.git' },
```