### PR TITLE
feat: support host:port

### DIFF
--- a/lib/giturl.js
+++ b/lib/giturl.js
@@ -14,8 +14,8 @@
  * Module dependencies.
  */
 
-// host[:/]n1/n2
-var RE = /^([^:\/]+)[:\/](.+)$/i;
+// host[:/]n1/n2 | host:port[:/]n1/n2
+var RE = /^([^:\/]+:\d{1,5}|[^:\/]+)[:\/](.+)$/i;
 
 var HTTPS_HOSTS = {
   'github.com': 1,


### PR DESCRIPTION
`git://gitlab.com:666/edp/logger.git` should be parse as `http://gitlab.com:666/edp/logger`