### PR TITLE
Fix public repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/repo-utils/giturl",
   "repository": {
     "type": "git",
-    "url": "git://github.com/repo-utils/giturl.git"
+    "url": "git+https://github.com/repo-utils/giturl.git"
   },
   "bugs": {
     "url": "https://github.com/repo-utils/giturl/issues"


### PR DESCRIPTION
This updates the package repository metadata to use a public HTTPS Git URL instead of the legacy `git://github.com` form.

The package is public, so tooling that reads `repository.url` can inspect or clone it over HTTPS without legacy git protocol handling.

Validation performed:
- `package.json` parses as JSON
- direct Node assertion confirms `repository.url === git+https://github.com/repo-utils/giturl.git`
- GitHub compare shows this PR changes only `package.json`

No runtime code, dependency, version, or package entrypoint changes.